### PR TITLE
Extract interface for AgentConnection, to make testing easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,24 +70,24 @@ follows:
 
     RemoteRunMaster master = new RemoteRunMaster(new AgentConnectionCallback() {
       @Override
-      public void agentConnected(AgentConnection agentConnection) {
+      public void agentConnected(IAgentConnection agentConnection) {
       }
 
       @Override
-      public void messageReceived(AgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
+      public void messageReceived(IAgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
       }
 
       @Override
-      public void agentDisconnected(AgentConnection agentConnection) {
+      public void agentDisconnected(IAgentConnection agentConnection) {
       }
     });
 
 To obtain the list of connected agents at a later point, you can use RemoteRunMaster.getConnectedClients:
 
-    for(AgentConnection connection : master.getConnectedClients()) {
+    for(IAgentConnection connection : master.getConnectedClients()) {
     }
 
-Once you have an AgentConnection object, you can run a command on an agent as follows:
+Once you have an IAgentConnection object, you can run a command on an agent as follows:
 
     RemoteRun.MasterToAgent.Builder command = MessageHelper.runCommand("/bin/echo", "Hello World!");
     TextOutputCallback callback = new TextOutputCallback() {
@@ -115,7 +115,7 @@ To send a file or directory to the agent:
 
     connection.upload(sourcePath, targetRootDirectory, new UploadCompleteCallback() {
       @Override
-      public void uploadComplete(AgentConnection agent, long requestId, String targetPath, boolean success) {
+      public void uploadComplete(IAgentConnection agent, long requestId, String targetPath, boolean success) {
         // do something on upload completion
       }
     });

--- a/embed/src/main/java/net/formicary/remoterun/embed/IAgentConnection.java
+++ b/embed/src/main/java/net/formicary/remoterun/embed/IAgentConnection.java
@@ -1,0 +1,46 @@
+package net.formicary.remoterun.embed;
+
+import java.nio.file.Path;
+
+import net.formicary.remoterun.common.proto.RemoteRun;
+import net.formicary.remoterun.embed.callback.FileDownloadCallback;
+import net.formicary.remoterun.embed.callback.UploadCompleteCallback;
+import net.formicary.remoterun.embed.request.AgentRequest;
+
+/**
+ * @author Hani Suleiman
+ */
+public interface IAgentConnection {
+  ConnectionState getConnectionState();
+
+  void setConnectionState(ConnectionState connectionState);
+
+  RemoteRun.AgentToMaster.AgentInfo getAgentInfo();
+
+  void setAgentInfo(RemoteRun.AgentToMaster.AgentInfo agentInfo);
+
+  /**
+   * Disconnect this agent.
+   */
+  void shutdown();
+
+  /**
+   * Initiate the upload of a file from master to agent.
+   *
+   * @param localSourcePath path to read and send on this host
+   * @param remoteTargetDirectory where to try and store the data on the target
+   * @param callback callback when the send is complete, can be null
+   * @return unique request ID
+   */
+  long upload(Path localSourcePath, String remoteTargetDirectory, UploadCompleteCallback callback);
+
+  long download(String remoteSourcePath, Path localTargetDirectory, FileDownloadCallback callback);
+
+  long request(AgentRequest message);
+
+  /**
+   * Transmit a message that has already been given a unique request ID, and commit to handling the responses yourself
+   * with the AgentConnectionCallback registered.
+   */
+  void write(RemoteRun.MasterToAgent message);
+}

--- a/embed/src/main/java/net/formicary/remoterun/embed/RemoteRunMaster.java
+++ b/embed/src/main/java/net/formicary/remoterun/embed/RemoteRunMaster.java
@@ -51,7 +51,7 @@ import static net.formicary.remoterun.embed.ConnectionState.*;
 public class RemoteRunMaster extends SimpleChannelHandler implements ChannelFutureListener {
   private static final Logger log = LoggerFactory.getLogger(RemoteRunMaster.class);
   private static final AtomicLong NEXT_REQUEST_ID = new AtomicLong();
-  private final Set<AgentConnection> agentConnections = new CopyOnWriteArraySet<>();
+  private final Set<IAgentConnection> agentConnections = new CopyOnWriteArraySet<>();
   private final ServerBootstrap bootstrap;
   private AgentConnectionCallback callback;
 
@@ -107,6 +107,9 @@ public class RemoteRunMaster extends SimpleChannelHandler implements ChannelFutu
     return NEXT_REQUEST_ID.getAndIncrement();
   }
 
+  /**
+   * Get the registered callback. Can be null.
+   */
   public AgentConnectionCallback getCallback() {
     return callback;
   }
@@ -182,7 +185,7 @@ public class RemoteRunMaster extends SimpleChannelHandler implements ChannelFutu
     ctx.sendUpstream(message);
   }
 
-  private static final String getPeerDn(Channel channel) {
+  private static String getPeerDn(Channel channel) {
     String peerDn;
     try {
       SSLEngine engine = channel.getPipeline().get(SslHandler.class).getEngine();
@@ -232,12 +235,12 @@ public class RemoteRunMaster extends SimpleChannelHandler implements ChannelFutu
     }
   }
 
-  public Set<AgentConnection> getAgentConnections() {
+  public Set<IAgentConnection> getAgentConnections() {
     return agentConnections;
   }
 
   public void shutdown() {
-    for(AgentConnection agentConnection : agentConnections) {
+    for(IAgentConnection agentConnection : agentConnections) {
       agentConnection.shutdown();
     }
     bootstrap.shutdown();
@@ -249,9 +252,9 @@ public class RemoteRunMaster extends SimpleChannelHandler implements ChannelFutu
    *
    * @return a fresh list, can be modified as you wish
    */
-  public Collection<AgentConnection> getConnectedClients() {
-    List<AgentConnection> result = new ArrayList<>();
-    for(AgentConnection agentConnection : agentConnections) {
+  public Collection<IAgentConnection> getConnectedClients() {
+    List<IAgentConnection> result = new ArrayList<>();
+    for(IAgentConnection agentConnection : agentConnections) {
       if(agentConnection.getConnectionState() == CONNECTED) {
         result.add(agentConnection);
       }

--- a/embed/src/main/java/net/formicary/remoterun/embed/callback/AbstractAgentConnectionCallback.java
+++ b/embed/src/main/java/net/formicary/remoterun/embed/callback/AbstractAgentConnectionCallback.java
@@ -17,7 +17,7 @@
 package net.formicary.remoterun.embed.callback;
 
 import net.formicary.remoterun.common.proto.RemoteRun;
-import net.formicary.remoterun.embed.AgentConnection;
+import net.formicary.remoterun.embed.IAgentConnection;
 
 /**
  * Convenience class to avoid having to implement all methods in AgentConnectionCallback.
@@ -26,17 +26,17 @@ import net.formicary.remoterun.embed.AgentConnection;
  */
 public class AbstractAgentConnectionCallback implements AgentConnectionCallback {
   @Override
-  public void agentConnected(AgentConnection agentConnection) {
+  public void agentConnected(IAgentConnection agentConnection) {
 
   }
 
   @Override
-  public void messageReceived(AgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
+  public void messageReceived(IAgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
 
   }
 
   @Override
-  public void agentDisconnected(AgentConnection agentConnection) {
+  public void agentDisconnected(IAgentConnection agentConnection) {
 
   }
 }

--- a/embed/src/main/java/net/formicary/remoterun/embed/callback/AgentConnectionCallback.java
+++ b/embed/src/main/java/net/formicary/remoterun/embed/callback/AgentConnectionCallback.java
@@ -17,15 +17,15 @@
 package net.formicary.remoterun.embed.callback;
 
 import net.formicary.remoterun.common.proto.RemoteRun;
-import net.formicary.remoterun.embed.AgentConnection;
+import net.formicary.remoterun.embed.IAgentConnection;
 
 /**
  * @author Chris Pearson
  */
 public interface AgentConnectionCallback {
-  void agentConnected(AgentConnection agentConnection);
+  void agentConnected(IAgentConnection agentConnection);
 
-  void messageReceived(AgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception;
+  void messageReceived(IAgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception;
 
-  void agentDisconnected(AgentConnection agentConnection);
+  void agentDisconnected(IAgentConnection agentConnection);
 }

--- a/embed/src/main/java/net/formicary/remoterun/embed/callback/UploadCompleteCallback.java
+++ b/embed/src/main/java/net/formicary/remoterun/embed/callback/UploadCompleteCallback.java
@@ -16,11 +16,11 @@
 
 package net.formicary.remoterun.embed.callback;
 
-import net.formicary.remoterun.embed.AgentConnection;
+import net.formicary.remoterun.embed.IAgentConnection;
 
 /**
  * @author Chris Pearson
  */
 public interface UploadCompleteCallback {
-  void uploadComplete(AgentConnection agent, long requestId, String targetPath, boolean success);
+  void uploadComplete(IAgentConnection agent, long requestId, String targetPath, boolean success);
 }

--- a/examples/src/main/java/net/formicary/remoterun/examples/DownloadingMaster.java
+++ b/examples/src/main/java/net/formicary/remoterun/examples/DownloadingMaster.java
@@ -20,7 +20,7 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import net.formicary.remoterun.embed.AgentConnection;
+import net.formicary.remoterun.embed.IAgentConnection;
 import net.formicary.remoterun.embed.RemoteRunMaster;
 import net.formicary.remoterun.embed.callback.AbstractAgentConnectionCallback;
 import net.formicary.remoterun.embed.callback.FileDownloadCallback;
@@ -37,14 +37,14 @@ public class DownloadingMaster {
   public static void main(String[] args) {
     new RemoteRunMaster(new AbstractAgentConnectionCallback() {
       @Override
-      public void agentConnected(AgentConnection agentConnection) {
+      public void agentConnected(IAgentConnection agentConnection) {
         // on connect download a file
         downloadFrom(agentConnection);
       }
     }).bind(new InetSocketAddress(1081));
   }
 
-  private static void downloadFrom(AgentConnection agentConnection) {
+  private static void downloadFrom(IAgentConnection agentConnection) {
     try {
       final Path tempDirectory = Files.createTempDirectory("RemoteRunExample_DownloadingMaster");
       agentConnection.download(REMOTE_SOURCE_FILE, tempDirectory, new FileDownloadCallback() {

--- a/examples/src/main/java/net/formicary/remoterun/examples/FileServer.java
+++ b/examples/src/main/java/net/formicary/remoterun/examples/FileServer.java
@@ -24,9 +24,9 @@ import java.util.concurrent.Executors;
 import net.formicary.remoterun.common.FileReceiver;
 import net.formicary.remoterun.common.IoUtils;
 import net.formicary.remoterun.common.proto.RemoteRun;
-import net.formicary.remoterun.embed.AgentConnection;
-import net.formicary.remoterun.embed.callback.AgentConnectionCallback;
+import net.formicary.remoterun.embed.IAgentConnection;
 import net.formicary.remoterun.embed.RemoteRunMaster;
+import net.formicary.remoterun.embed.callback.AgentConnectionCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,13 +55,13 @@ public class FileServer implements AgentConnectionCallback {
   }
 
   @Override
-  public void agentConnected(final AgentConnection agentConnection) {
+  public void agentConnected(final IAgentConnection agentConnection) {
     // sending a file
     uploadId = agentConnection.upload(Paths.get(DEMO_REQUEST_PATH), "demopath", null);
   }
 
   @Override
-  public void messageReceived(AgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
+  public void messageReceived(IAgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
     if(message.getMessageType() == RECEIVED_DATA && message.getRequestId() == uploadId) {
       log.info("Completed receipt of system.log, re-downloading...");
       // now we've sent a file to the agent, re-download
@@ -92,6 +92,6 @@ public class FileServer implements AgentConnectionCallback {
   }
 
   @Override
-  public void agentDisconnected(AgentConnection agentConnection) {
+  public void agentDisconnected(IAgentConnection agentConnection) {
   }
 }

--- a/examples/src/main/java/net/formicary/remoterun/examples/SimpleRemoteRunMaster.java
+++ b/examples/src/main/java/net/formicary/remoterun/examples/SimpleRemoteRunMaster.java
@@ -19,11 +19,11 @@ package net.formicary.remoterun.examples;
 import java.net.InetSocketAddress;
 
 import net.formicary.remoterun.common.proto.RemoteRun;
-import net.formicary.remoterun.embed.AgentConnection;
+import net.formicary.remoterun.embed.IAgentConnection;
 import net.formicary.remoterun.embed.RemoteRunMaster;
-import net.formicary.remoterun.embed.request.TextOutputRequest;
+import net.formicary.remoterun.embed.callback.AbstractAgentConnectionCallback;
 import net.formicary.remoterun.embed.callback.AbstractTextOutputCallback;
-import net.formicary.remoterun.embed.callback.AgentConnectionCallback;
+import net.formicary.remoterun.embed.request.TextOutputRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ import static net.formicary.remoterun.embed.request.MessageHelper.runCommand;
  *
  * @author Chris Pearson
  */
-public class SimpleRemoteRunMaster implements AgentConnectionCallback {
+public class SimpleRemoteRunMaster extends AbstractAgentConnectionCallback {
   private static final Logger log = LoggerFactory.getLogger(SimpleRemoteRunMaster.class);
 
   public static void main(String[] args) {
@@ -54,7 +54,7 @@ public class SimpleRemoteRunMaster implements AgentConnectionCallback {
     } catch(InterruptedException ignored) {
     }
     // run a command on all connected clients
-    for(AgentConnection connection : master.getConnectedClients()) {
+    for(IAgentConnection connection : master.getConnectedClients()) {
       connection.write(RemoteRun.MasterToAgent.newBuilder()
         .setMessageType(RUN_COMMAND)
         .setRequestId(RemoteRunMaster.getNextRequestId())
@@ -71,21 +71,11 @@ public class SimpleRemoteRunMaster implements AgentConnectionCallback {
   }
 
   @Override
-  public void agentConnected(final AgentConnection agentConnection) {
+  public void agentConnected(final IAgentConnection agentConnection) {
     // as soon as an agent connects, run a command
     agentConnection.request(new TextOutputRequest(runCommand("echo", "Hello World!"), new AbstractTextOutputCallback() {
       // nothing overridden because we don't actually want to do anything with the command - pretty unusual, we'd
       // normally want to check at least the exit code to check if it succeeded or failed
     }));
-  }
-
-  @Override
-  public void messageReceived(AgentConnection agentConnection, RemoteRun.AgentToMaster message) throws Exception {
-    // nothing needs doing here
-  }
-
-  @Override
-  public void agentDisconnected(AgentConnection agentConnection) {
-    // nothing needs doing here
   }
 }

--- a/examples/src/main/java/net/formicary/remoterun/examples/UploadingMaster.java
+++ b/examples/src/main/java/net/formicary/remoterun/examples/UploadingMaster.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import net.formicary.remoterun.embed.AgentConnection;
+import net.formicary.remoterun.embed.IAgentConnection;
 import net.formicary.remoterun.embed.RemoteRunMaster;
 import net.formicary.remoterun.embed.callback.AbstractAgentConnectionCallback;
 import net.formicary.remoterun.embed.callback.UploadCompleteCallback;
@@ -38,19 +38,19 @@ public class UploadingMaster {
   public static void main(String[] args) {
     new RemoteRunMaster(new AbstractAgentConnectionCallback() {
       @Override
-      public void agentConnected(AgentConnection agentConnection) {
+      public void agentConnected(IAgentConnection agentConnection) {
         // on connect upload a file
         uploadTo(agentConnection);
       }
     }).bind(new InetSocketAddress(1081));
   }
 
-  private static void uploadTo(AgentConnection agentConnection) {
+  private static void uploadTo(IAgentConnection agentConnection) {
     try {
       final Path tempDirectory = Files.createTempDirectory("RemoteRunExample_UploadingMaster");
       agentConnection.upload(Paths.get(LOCAL_SOURCE_FILE), tempDirectory.toString(), new UploadCompleteCallback() {
         @Override
-        public void uploadComplete(AgentConnection agent, long requestId, String targetPath, boolean success) {
+        public void uploadComplete(IAgentConnection agent, long requestId, String targetPath, boolean success) {
           log.info("File upload of {} to {} complete, success={}", LOCAL_SOURCE_FILE, tempDirectory, success);
         }
       });


### PR DESCRIPTION
AgentConnection currently is a concrete implementation with channels and all manner of IO.

This means that it's impossible to test RemoteRunMaster without a lot of mocking or by using IO, neither of which is desirable.

By adding an interface (IAgentConnection, happy to change the name if you have something better), we can allow for different implementations such as an in-memory one, or a stub that can be used for testing.

It also protects callers from calling implementation methods that are not part of the contract (such as getChannel).
