### PR TITLE
Update protoc-plugin location

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,7 +28,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>protoc-plugin</id>
-      <url>http://sergei-ivanov.github.com/maven-protoc-plugin/repo/releases/</url>
+      <url>https://dl.bintray.com/sergei-ivanov/maven</url>
     </pluginRepository>
   </pluginRepositories>
   <build>


### PR DESCRIPTION
The old protoc-plugin maven repository is no longer available; archived releases are available through bintray.com.